### PR TITLE
(fix) workaround for *ngFor not resetting `odd` on sort, refs #51

### DIFF
--- a/skawa_material_components/lib/data_table/data_table.html
+++ b/skawa_material_components/lib/data_table/data_table.html
@@ -25,11 +25,11 @@
     </tr>
     </thead>
     <tbody>
-    <tr *ngFor="let row of rows; let odd=odd"
+    <tr *ngFor="let row of rows; let index=index"
         [ngClass]="row.classes"
         [class.selected]="row.checked"
-        [class.odd-row]="odd"
-        [class.even-row]="!odd"
+        [class.odd-row]="index % 2 != 0"
+        [class.even-row]="index % 2 == 0"
         (click)="highlight(row, $event); $event.stopPropagation()"
         [class.highlighted]="row == highlightedRow">
         <td *ngIf="selectable">

--- a/skawa_material_components/test/data_table_po.dart
+++ b/skawa_material_components/test/data_table_po.dart
@@ -83,6 +83,8 @@ abstract class TableRowPO {
 
   @ByTagName('td')
   List<TableCellPO> get td;
+
+  String get classes => rootElement.attributes['class'];
 }
 
 @PageObject()


### PR DESCRIPTION
`*ngFor` is being a bad boy. To save CPU cycles, ngFor doesn't rebuild its contents, rather it just reorganizes the children. For that reason, there are cases that even and odd calculations are off if elements are left in-place.

To rectify it, data table rows use computed `odd` locals instead of relying on locals provided by `*ngFor`.

An alternative solution could be to completely remove `[class.odd-row]="index % 2 != 0"` and `[class.even-row]="index % 2 == 0"`, then update the scss with `&:nth-child(odd)` selector. This way the striping would be left to be done by the browser.

Should close #51 