### PR TITLE
(feat) add feature toggle directives

### DIFF
--- a/skawa_components/CHANGELOG.md
+++ b/skawa_components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+- New structural directives: `[featureEnabled]` and `[featureDisabled]`
+
 ## 1.3.3
 
 - patch version for 6.0.0-alpha

--- a/skawa_components/README.md
+++ b/skawa_components/README.md
@@ -17,6 +17,10 @@ The goal is to share a couple of components which are used internally but not ma
 * ✓ `<skawa-nav-item>`
 * ✓ `<skawa-sidebar-item>`
 
+**Currently Available directives**:
+
+* ✓ `*featureEnabled` and `*featureDisabled`
+
 **Currently Available pipes:**
 
 * ✓ `hexColorize`

--- a/skawa_components/lib/feature_toggle/feature_toggle.dart
+++ b/skawa_components/lib/feature_toggle/feature_toggle.dart
@@ -18,6 +18,7 @@ abstract class FeatureToggleBase {
 
   bool shouldDisplay(String featureName);
 
+  /// Inserts or removes [_templateRef] based on the enabled state of a feature
   void toggleDisplay(String name, TemplateRef _templateRef, ViewContainerRef _viewContainer) {
     final isFeatureShown = shouldDisplay(name);
     // if feature is the same and its state is the same as previously,
@@ -26,6 +27,7 @@ abstract class FeatureToggleBase {
       return;
     }
     if (isFeatureShown) {
+      _viewContainer.clear();
       _viewContainer.createEmbeddedView(_templateRef);
     } else {
       _viewContainer.clear();
@@ -45,9 +47,8 @@ class FeatureToggleEnabledDirective extends FeatureToggleBase {
   final TemplateRef _templateRef;
   final ViewContainerRef _viewContainer;
 
-  FeatureToggleEnabledDirective(this._templateRef, this._viewContainer, @Optional() FeatureToggleService toggleService)
-      : assert(toggleService != null),
-        super(toggleService);
+  FeatureToggleEnabledDirective(this._templateRef, this._viewContainer, FeatureToggleService toggleService)
+      : super(toggleService);
 
   @Input('featureEnabled')
   set featureName(String name) {
@@ -68,8 +69,7 @@ class FeatureToggleDisabledDirective extends FeatureToggleBase {
   final ViewContainerRef _viewContainer;
 
   FeatureToggleDisabledDirective(this._templateRef, this._viewContainer, FeatureToggleService toggleService)
-      : assert(toggleService != null),
-        super(toggleService);
+      : super(toggleService);
 
   @Input('featureDisabled')
   set featureName(String name) {

--- a/skawa_components/lib/feature_toggle/feature_toggle.dart
+++ b/skawa_components/lib/feature_toggle/feature_toggle.dart
@@ -1,0 +1,85 @@
+import 'package:angular/angular.dart' show TemplateRef, ViewContainerRef, Directive, Input, Optional;
+import 'package:meta/meta.dart' show visibleForTesting;
+
+/// Base class for FeatureToggle directives that is queried
+/// if a feature is enabled or not.
+///
+/// Used by [FeatureToggleEnabledDirective] & [FeatureToggleDisabledDirective]
+abstract class FeatureToggleService {
+
+  /// Determines if a feature is enabled or not
+  bool isEnabled(String featureName);
+}
+
+@visibleForTesting
+abstract class FeatureToggleBase {
+  final FeatureToggleService toggleService;
+
+  FeatureToggleBase(this.toggleService);
+
+  bool shouldDisplay(String featureName);
+
+  void toggleDisplay(String name, TemplateRef _templateRef, ViewContainerRef _viewContainer) {
+    final isFeatureShown = shouldDisplay(name);
+    // if feature is the same and its state is the same as previously,
+    // do nothing
+    if (name == _previousFeature && isFeatureShown == _previouslyShown) {
+      return;
+    }
+    if (isFeatureShown) {
+      _viewContainer.createEmbeddedView(_templateRef);
+    } else {
+      _viewContainer.clear();
+    }
+    _previouslyShown = isFeatureShown;
+    _previousFeature = name;
+  }
+
+  bool _previouslyShown;
+  String _previousFeature;
+}
+
+
+@Directive(
+  selector: '[featureEnabled]',
+)
+class FeatureToggleEnabledDirective extends FeatureToggleBase {
+  final TemplateRef _templateRef;
+  final ViewContainerRef _viewContainer;
+
+  FeatureToggleEnabledDirective(this._templateRef, this._viewContainer, @Optional() FeatureToggleService toggleService)
+      : assert(toggleService != null),
+        super(toggleService);
+
+  @Input('featureEnabled')
+  set featureName(String name) {
+    toggleDisplay(name, _templateRef, _viewContainer);
+  }
+
+  @override
+  bool shouldDisplay(String featureName) {
+    return toggleService.isEnabled(featureName);
+  }
+}
+
+@Directive(
+  selector: '[featureDisabled]',
+)
+class FeatureToggleDisabledDirective extends FeatureToggleBase {
+  final TemplateRef _templateRef;
+  final ViewContainerRef _viewContainer;
+
+  FeatureToggleDisabledDirective(this._templateRef, this._viewContainer, FeatureToggleService toggleService)
+      : assert(toggleService != null),
+        super(toggleService);
+
+  @Input('featureDisabled')
+  set featureName(String name) {
+    toggleDisplay(name, _templateRef, _viewContainer);
+  }
+
+  @override
+  bool shouldDisplay(String featureName) {
+    return !toggleService.isEnabled(featureName);
+  }
+}

--- a/skawa_components/lib/feature_toggle/feature_toggle.dart
+++ b/skawa_components/lib/feature_toggle/feature_toggle.dart
@@ -6,7 +6,6 @@ import 'package:meta/meta.dart' show visibleForTesting;
 ///
 /// Used by [FeatureToggleEnabledDirective] & [FeatureToggleDisabledDirective]
 abstract class FeatureToggleService {
-
   /// Determines if a feature is enabled or not
   bool isEnabled(String featureName);
 }
@@ -38,7 +37,6 @@ abstract class FeatureToggleBase {
   bool _previouslyShown;
   String _previousFeature;
 }
-
 
 @Directive(
   selector: '[featureEnabled]',

--- a/skawa_components/pubspec.yaml
+++ b/skawa_components/pubspec.yaml
@@ -1,5 +1,5 @@
 name: skawa_components
-version: 1.3.3
+version: 1.4.0
 authors:
   - Harsányi Tamás (valakis) <tams.harsnyi@google.com>
   - Szepesházi András <szepeshazi@gmail.com>
@@ -20,6 +20,7 @@ dependencies:
   js: ^0.6.1+1
   intl: ^0.15.7
   diff_match_patch: ^0.3.0
+  meta: ^1.2.2
 
 dev_dependencies:
   html_unescape: ^1.0.1+2

--- a/skawa_components/test/feature_toggle_test.dart
+++ b/skawa_components/test/feature_toggle_test.dart
@@ -123,7 +123,7 @@ void main() {
     tearDown(() async {
       await disposeAnyRunningTest();
     });
-    test('changing eature updates UI', () async {
+    test('changing feature updates UI', () async {
       final mockService = MockToggleService();
       when(mockService.isEnabled(captureAny)).thenAnswer((realInvocation) {
         final featureName = realInvocation.positionalArguments.first as String;
@@ -181,7 +181,17 @@ class TestStructuralComponent {}
   changeDetection: ChangeDetectionStrategy.OnPush,
 )
 class TestUpdatableStructuralComponent {
-  String featureName = 'disabledFeature';
+  final ChangeDetectorRef changeDetectorRef;
+  String _featureName = 'disabledFeature';
+
+  TestUpdatableStructuralComponent(this.changeDetectorRef);
+
+  String get featureName => _featureName;
+
+  set featureName(String value) {
+    _featureName = value;
+    changeDetectorRef.markForCheck();
+  }
 }
 
 class TestFeatureToggleImpl extends FeatureToggleBase {

--- a/skawa_components/test/feature_toggle_test.dart
+++ b/skawa_components/test/feature_toggle_test.dart
@@ -1,0 +1,224 @@
+@TestOn('browser')
+import 'package:angular_test/angular_test.dart';
+import 'package:angular/angular.dart';
+import 'package:angular/src/di/injector/hierarchical.dart';
+import 'package:mockito/mockito.dart';
+import 'package:skawa_components/feature_toggle/feature_toggle.dart';
+import 'package:test/test.dart';
+
+import 'feature_toggle_test.template.dart' as self;
+
+void main() {
+  setUpAll(() {
+    self.initReflector();
+  });
+  group('FeatureToggleBase', () {
+    final mockViewContainerRef = MockViewContainerRef();
+    setUp(() {
+      reset(mockViewContainerRef);
+      when(mockViewContainerRef.createEmbeddedView(any)).thenReturn(null);
+      when(mockViewContainerRef.clear()).thenReturn(Null);
+    });
+    test('toggleDisplay should invoked shouldDisplay', () {
+      final inst = enabledToggleBase;
+      inst.toggleDisplay('SomeFeature', null, mockViewContainerRef);
+      expect(inst.lastCheckedFeature, 'SomeFeature');
+    });
+    test('toggleDisplay should short circuit of feature name and state matches', () {
+      final inst = disabledToggleBase;
+      inst.toggleDisplay('SomeFeature', null, mockViewContainerRef);
+      verify(mockViewContainerRef.clear());
+      expect(() => inst.toggleDisplay('SomeFeature', null, mockViewContainerRef), returnsNormally);
+      verifyNoMoreInteractions(mockViewContainerRef);
+    });
+    test('toggleDisplay should hide when feature changes', () {
+      final inst = disabledToggleBase;
+      inst.toggleDisplay('SomeFeature', null, mockViewContainerRef);
+      expect(() => inst.toggleDisplay('OtherFeature', null, mockViewContainerRef), returnsNormally);
+      verify(mockViewContainerRef.clear()).called(2);
+      verifyNoMoreInteractions(mockViewContainerRef);
+    });
+    test('toggleDisplay should toggles when feature display state changes', () {
+      final inst = disabledToggleBase;
+      inst.toggleDisplay('SomeFeature', null, mockViewContainerRef);
+      inst.testShouldDisplay = true;
+      expect(() => inst.toggleDisplay('SomeFeature', null, mockViewContainerRef), returnsNormally);
+      verify(mockViewContainerRef.clear());
+      verify(mockViewContainerRef.createEmbeddedView(any));
+      verifyNoMoreInteractions(mockViewContainerRef);
+    });
+  });
+  group('FeatureToggleDirectives', () {
+    group('when feature is enabled', () {
+      tearDown(() async {
+        await disposeAnyRunningTest();
+      });
+      final rootInjectorCb = ([Injector parent]) {
+        return Injector.map({
+          FeatureToggleService: enabledTestService,
+        }, parent as HierarchicalInjector);
+      };
+      test('with [featureEnabled] creates embedded view', () async {
+        final bed = NgTestBed.forComponent(self.TestEnabledComponentNgFactory, rootInjector: rootInjectorCb);
+        final fixture = await bed.create();
+        expect(fixture.text, contains('Displayed'));
+      });
+      test('with [featureDisabled] clears embedded view', () async {
+        final bed = NgTestBed.forComponent(self.TestDisabledComponentNgFactory, rootInjector: rootInjectorCb);
+        final fixture = await bed.create();
+        expect(fixture.text, isEmpty);
+      });
+    });
+    group('when feature is disabled', () {
+      tearDown(() async {
+        await disposeAnyRunningTest();
+      });
+      final rootInjectorCb = ([Injector parent]) {
+        return Injector.map({
+          FeatureToggleService: disabledTestService,
+        }, parent as HierarchicalInjector);
+      };
+      test('with [featureEnabled] clears embedded view', () async {
+        final bed = NgTestBed.forComponent(self.TestEnabledComponentNgFactory, rootInjector: rootInjectorCb);
+        final fixture = await bed.create();
+        expect(fixture.text, isEmpty);
+      });
+      test('with [featureDisabled] creates embedded view', () async {
+        final bed = NgTestBed.forComponent(self.TestDisabledComponentNgFactory, rootInjector: rootInjectorCb);
+        final fixture = await bed.create();
+        expect(fixture.text, contains('Displayed'));
+      });
+    });
+  });
+  group('FeatureToggleStructureDirective', () {
+    tearDown(() async {
+      await disposeAnyRunningTest();
+    });
+    test('when feature is enabled, should display and hide appropriately', () async {
+      final bed = NgTestBed.forComponent(self.TestStructuralComponentNgFactory, rootInjector: ([Injector parent]) {
+        return Injector.map({
+          FeatureToggleService: enabledTestService,
+        }, parent as HierarchicalInjector);
+      });
+      final fixture = await bed.create();
+      expect(fixture.text, contains('EnabledCheck'));
+      expect(fixture.text, isNot(contains('DisabledCheck')));
+    });
+    test('when feature is disabled, should display and hide appropriately', () async {
+      final bed = NgTestBed.forComponent(self.TestStructuralComponentNgFactory, rootInjector: ([Injector parent]) {
+        return Injector.map({
+          FeatureToggleService: disabledTestService,
+        }, parent as HierarchicalInjector);
+      });
+      final fixture = await bed.create();
+      expect(fixture.text, isNot(contains('EnabledCheck')));
+      expect(fixture.text, contains('DisabledCheck'));
+    });
+  });
+  group('changing feature name', () {
+    const features = {
+      'enabledFeature': true,
+      'disabledFeature': false,
+    };
+    tearDown(() async {
+      await disposeAnyRunningTest();
+    });
+    test('changing eature updates UI', () async {
+      final mockService = MockToggleService();
+      when(mockService.isEnabled(captureAny)).thenAnswer((realInvocation) {
+        final featureName = realInvocation.positionalArguments.first as String;
+        return features[featureName];
+      });
+      final bed = NgTestBed.forComponent<TestUpdatableStructuralComponent>(
+          self.TestUpdatableStructuralComponentNgFactory, rootInjector: ([Injector parent]) {
+        return Injector.map({
+          FeatureToggleService: mockService,
+        }, parent as HierarchicalInjector);
+      });
+      final fixture = await bed.create();
+      expect(fixture.text, isEmpty);
+      await fixture.update((inst) {
+        inst.featureName = 'enabledFeature';
+      });
+      expect(fixture.text, contains('enabledFeature'));
+    });
+  });
+}
+
+@Component(
+  selector: 'test-cmp',
+  template: '<template featureEnabled="SomeFeature">Displayed</template>',
+  directives: [FeatureToggleEnabledDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+)
+class TestEnabledComponent {}
+
+@Component(
+  selector: 'test-cmp',
+  template: '<template featureDisabled="SomeFeature">Displayed</template>',
+  directives: [FeatureToggleDisabledDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+)
+class TestDisabledComponent {}
+
+@Component(
+  selector: 'test-cmp',
+  template: '''
+  <span *featureEnabled="'SomeFeature'">EnabledCheck</span>
+  <span *featureDisabled="'SomeFeature'">DisabledCheck</span>
+  ''',
+  directives: [FeatureToggleEnabledDirective, FeatureToggleDisabledDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+)
+class TestStructuralComponent {}
+
+@Component(
+  selector: 'test-cmp',
+  template: '''
+  <span *featureEnabled="featureName">{{featureName}}</span>
+  ''',
+  directives: [FeatureToggleEnabledDirective, FeatureToggleDisabledDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+)
+class TestUpdatableStructuralComponent {
+  String featureName = 'disabledFeature';
+}
+
+class TestFeatureToggleImpl extends FeatureToggleBase {
+  bool testShouldDisplay;
+  String lastCheckedFeature;
+
+  TestFeatureToggleImpl(FeatureToggleService toggleService) : super(toggleService);
+
+  @override
+  bool shouldDisplay(String featureName) {
+    lastCheckedFeature = featureName;
+    return testShouldDisplay;
+  }
+}
+
+TestFeatureToggleImpl get enabledToggleBase => TestFeatureToggleImpl(null)..testShouldDisplay = true;
+
+TestFeatureToggleImpl get disabledToggleBase => TestFeatureToggleImpl(null)..testShouldDisplay = false;
+
+class MockViewContainerRef extends Mock implements ViewContainerRef {}
+
+class MockToggleService extends Mock implements FeatureToggleService {}
+
+FeatureToggleService enabledToggleServiceFactory() => enabledTestService;
+
+FeatureToggleService disabledToggleServiceFactory() => disabledTestService;
+
+/// A service always returns true for `isEnabled`
+FeatureToggleService get enabledTestService {
+  final mock = MockToggleService();
+  when(mock.isEnabled(any)).thenReturn(true);
+  return mock;
+}
+
+/// A service always returns false for `isEnabled`
+FeatureToggleService get disabledTestService {
+  final mock = MockToggleService();
+  when(mock.isEnabled(any)).thenReturn(false);
+  return mock;
+}


### PR DESCRIPTION
Feature toggle directives are simple structural directives (much like `NgIf`) that determine a template should be displayed or hidden. 
Displaying or hiding a "feature" is determined by an implementation of a service: `FeatureToggleService` which must be provided before using any of the directives.

Please see usage examples in `skawa_components/test/feature_toggle_test.dart`