### PR TITLE
Ckeditor event listener

### DIFF
--- a/skawa_components/CHANGELOG.md
+++ b/skawa_components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+- Made CKEditor change event working
+
 ## 1.5.0
 
 - angular updated to the stable 6.0.0 version

--- a/skawa_components/lib/ckeditor/ckeditor.dart
+++ b/skawa_components/lib/ckeditor/ckeditor.dart
@@ -52,14 +52,12 @@ class SkawaCkeditorComponent implements AfterViewInit, OnDestroy {
 
   String get value => _ckeditor.getEditorData();
 
-
-
   @override
   void ngAfterViewInit() {
-      _ckeditor ??= _CKEditor(editorName, extraPlugins: extraPlugins, configUrl: configUrl, config: config);
-      _ckeditor.on('change', (_) {
-        _changeController.add(value);
-      });
+    _ckeditor ??= _CKEditor(editorName, extraPlugins: extraPlugins, configUrl: configUrl, config: config);
+    _ckeditor.on('change', (_) {
+      _changeController.add(value);
+    });
   }
 
   @override

--- a/skawa_components/lib/ckeditor/ckeditor.dart
+++ b/skawa_components/lib/ckeditor/ckeditor.dart
@@ -52,8 +52,13 @@ class SkawaCkeditorComponent implements AfterViewInit, OnDestroy {
   String get value => _ckeditor.getEditorData();
 
   @override
-  void ngAfterViewInit() =>
+  void ngAfterViewInit() {
+
       _ckeditor ??= _CKEditor(editorName, extraPlugins: extraPlugins, configUrl: configUrl, config: config);
+      _ckeditor.on('change', () {
+        _changeController.add(value);
+      });
+  }
 
   @override
   void ngOnDestroy() {
@@ -88,6 +93,10 @@ class _CKEditor {
 
   String getEditorData() {
     return _jsEditorInstance.getData();
+  }
+
+  void on(String eventName, js_ck.EventCallback callback) {
+    return _jsEditorInstance.on(eventName, callback);
   }
 
   void _maybeAddExtraPlugins(Iterable<ExtraPlugin> extraPlugins) {

--- a/skawa_components/lib/ckeditor/ckeditor.dart
+++ b/skawa_components/lib/ckeditor/ckeditor.dart
@@ -57,7 +57,7 @@ class SkawaCkeditorComponent implements AfterViewInit, OnDestroy {
   @override
   void ngAfterViewInit() {
       _ckeditor ??= _CKEditor(editorName, extraPlugins: extraPlugins, configUrl: configUrl, config: config);
-      _ckeditor.on('change', () {
+      _ckeditor.on('change', (_) {
         _changeController.add(value);
       });
   }
@@ -98,7 +98,6 @@ class _CKEditor {
   }
 
   void on(String eventName, js_ck.EventCallback callback) {
-    print(eventName);
     return _jsEditorInstance.on(eventName, allowInterop(callback));
   }
 

--- a/skawa_components/lib/ckeditor/ckeditor.dart
+++ b/skawa_components/lib/ckeditor/ckeditor.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:js_util';
 
 import 'package:angular/angular.dart';
+import 'package:js/js.dart';
 
 import 'ckeditor_interop.dart' as js_ck;
 
@@ -51,9 +52,10 @@ class SkawaCkeditorComponent implements AfterViewInit, OnDestroy {
 
   String get value => _ckeditor.getEditorData();
 
+
+
   @override
   void ngAfterViewInit() {
-
       _ckeditor ??= _CKEditor(editorName, extraPlugins: extraPlugins, configUrl: configUrl, config: config);
       _ckeditor.on('change', () {
         _changeController.add(value);
@@ -96,7 +98,8 @@ class _CKEditor {
   }
 
   void on(String eventName, js_ck.EventCallback callback) {
-    return _jsEditorInstance.on(eventName, callback);
+    print(eventName);
+    return _jsEditorInstance.on(eventName, allowInterop(callback));
   }
 
   void _maybeAddExtraPlugins(Iterable<ExtraPlugin> extraPlugins) {

--- a/skawa_components/lib/ckeditor/ckeditor_interop.dart
+++ b/skawa_components/lib/ckeditor/ckeditor_interop.dart
@@ -21,7 +21,15 @@ class CKEditorInstance {
   external void on(String eventName, EventCallback callback);
 }
 
+@JS()
+@anonymous
+class EventInfo {
+    external CKEditorInstance get editor;
+
+    external factory EventInfo({CKEditorInstance editor});
+}
+
 @JS('CKEDITOR.plugins.addExternal')
 external void addExternalPlugin(String name, String path, String fileName);
 
-typedef EventCallback = void Function();
+typedef EventCallback = void Function(EventInfo evt);

--- a/skawa_components/lib/ckeditor/ckeditor_interop.dart
+++ b/skawa_components/lib/ckeditor/ckeditor_interop.dart
@@ -17,7 +17,11 @@ class CKEditorInstance {
   external String get name;
 
   external String getData();
+
+  external void on(String eventName, EventCallback callback)
 }
 
 @JS('CKEDITOR.plugins.addExternal')
 external void addExternalPlugin(String name, String path, String fileName);
+
+typedef EventCallback = void Function();

--- a/skawa_components/lib/ckeditor/ckeditor_interop.dart
+++ b/skawa_components/lib/ckeditor/ckeditor_interop.dart
@@ -24,9 +24,9 @@ class CKEditorInstance {
 @JS()
 @anonymous
 class EventInfo {
-    external CKEditorInstance get editor;
+  external CKEditorInstance get editor;
 
-    external factory EventInfo({CKEditorInstance editor});
+  external factory EventInfo({CKEditorInstance editor});
 }
 
 @JS('CKEDITOR.plugins.addExternal')

--- a/skawa_components/lib/ckeditor/ckeditor_interop.dart
+++ b/skawa_components/lib/ckeditor/ckeditor_interop.dart
@@ -18,7 +18,7 @@ class CKEditorInstance {
 
   external String getData();
 
-  external void on(String eventName, EventCallback callback)
+  external void on(String eventName, EventCallback callback);
 }
 
 @JS('CKEDITOR.plugins.addExternal')

--- a/skawa_components/pubspec.yaml
+++ b/skawa_components/pubspec.yaml
@@ -1,5 +1,5 @@
 name: skawa_components
-version: 1.5.0
+version: 1.5.1
 authors:
   - Harsányi Tamás (valakis) <tams.harsnyi@google.com>
   - Szepesházi András <szepeshazi@gmail.com>

--- a/skawa_components/pubspec.yaml
+++ b/skawa_components/pubspec.yaml
@@ -27,7 +27,10 @@ dev_dependencies:
   mockito: ^4.0.0
   test: ^1.6.2
   angular_test: ^3.0.0
-  pageloader: ^3.2.0
+  pageloader:
+    git:
+      url: https://github.com/skawa-universe/pageloader.git
+      ref: analyzer-40
   build_config: ^0.4.1+1
   build_test: ^1.0.0
   build_runner: ^1.7.0


### PR DESCRIPTION
# About 
When I was working with the `SkawaCkeditorComponent` I discovered that it has a change output but it doesn't do anything. Because the event listener is missing from the current JS interop.
# Development
I looked at the API reference of CKEditor, and found the following: you can call the `on` method on the instance (`https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-on`) with the `change` event (`https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change`) to listen  the changes of content of the editor.
Following the docs, I added the methods and classes needed to thew interop to communicate with JS code and and in the component used them.
I actually tested the modification by using this branch in other project.  